### PR TITLE
Bugfix/resolve routes

### DIFF
--- a/packages/core/src/fiber/fiber.ts
+++ b/packages/core/src/fiber/fiber.ts
@@ -2,7 +2,7 @@ import { detectIsTagVirtualNode, detectIsPlainVirtualNode, detectAreSameComponen
 import { type Instance, type Callback, type TimerId } from '../shared';
 import { type Context, type ContextProviderValue } from '../context';
 import { detectIsComponent } from '../component';
-import { detectIsFunction } from '../utils';
+import { detectIsFunction, error } from '../utils';
 import { type Atom } from '../atom';
 import { $$scope } from '../scope';
 
@@ -72,11 +72,14 @@ class Fiber<N = NativeElement> {
     }
   }
 
-  setError(error: Error) {
+  setError(err: Error) {
     if (detectIsFunction(this.catch)) {
-      this.catch(error);
+      this.catch(err);
+      error(err);
     } else if (this.parent) {
-      this.parent.setError(error);
+      this.parent.setError(err);
+    } else {
+      throw err;
     }
   }
 

--- a/packages/core/src/utils/utils.ts
+++ b/packages/core/src/utils/utils.ts
@@ -23,6 +23,8 @@ const detectIsEmpty = (o: any) => detectIsNull(o) || detectIsUndefined(o);
 
 const detectIsFalsy = (o: any) => detectIsEmpty(o) || o === false;
 
+const detectIsPromise = <T = unknown>(o: any): o is Promise<T> => o instanceof Promise;
+
 const getTime = () => Date.now();
 
 const dummyFn = () => {};
@@ -102,6 +104,7 @@ export {
   detectIsNull,
   detectIsEmpty,
   detectIsFalsy,
+  detectIsPromise,
   getTime,
   dummyFn,
   trueFn,

--- a/packages/core/src/workloop/workloop.ts
+++ b/packages/core/src/workloop/workloop.ts
@@ -22,6 +22,7 @@ import {
   detectIsArray,
   detectIsFunction,
   detectIsTextBased,
+  detectIsPromise,
   createIndexKey,
   trueFn,
 } from '../utils';
@@ -53,12 +54,9 @@ import { type RestoreOptions, scheduler } from '../scheduler';
 import { Fragment, detectIsFragment } from '../fragment';
 import { unmountFiber } from '../unmount';
 
-let hasPendingPromise = false;
+export type WorkLoop = (isAsync: boolean) => boolean | Promise<unknown> | null;
 
-export type WorkLoop = (isAsync: boolean) => boolean;
-
-function workLoop(isAsync: boolean): boolean | null {
-  if (hasPendingPromise) return null;
+function workLoop(isAsync: boolean): boolean | Promise<unknown> | null {
   const $scope = $$scope();
   const wipFiber = $scope.getWorkInProgress();
   let unit = $scope.getNextUnitOfWork();
@@ -78,12 +76,8 @@ function workLoop(isAsync: boolean): boolean | null {
       commit($scope);
     }
   } catch (err) {
-    if (err instanceof Promise) {
-      hasPendingPromise = true;
-      err.finally(() => {
-        hasPendingPromise = false;
-        !isAsync && workLoop(false);
-      });
+    if (detectIsPromise(err)) {
+      return err;
     } else {
       const emitter = $scope.getEmitter();
 
@@ -378,7 +372,7 @@ function mount(fiber: Fiber, prev: Fiber, $scope: Scope) {
       component.children = result as Array<Instance>;
       platform.detectIsPortal(inst) && fiber.markHost(PORTAL_HOST_MASK);
     } catch (err) {
-      if (err instanceof Promise) throw err;
+      if (detectIsPromise(err)) throw err;
       component.children = [];
       fiber.setError(err);
     }

--- a/packages/core/src/workloop/workloop.ts
+++ b/packages/core/src/workloop/workloop.ts
@@ -381,7 +381,6 @@ function mount(fiber: Fiber, prev: Fiber, $scope: Scope) {
       if (err instanceof Promise) throw err;
       component.children = [];
       fiber.setError(err);
-      error(err);
     }
   } else if (detectIsVirtualNodeFactory(inst)) {
     inst = inst();

--- a/packages/styled/README.md
+++ b/packages/styled/README.md
@@ -476,7 +476,7 @@ const GlobalStyle = createGlobalStyle<{ $light?: boolean }>`
 ```
 ## Theming
 
-The styled offers complete theming support by exporting a `<ThemeProvider>` wrapper component. This component supplies a theme to all its child components through the context API. Consequently, all styled components in the render tree, regardless of their depth, can access the provided theme.
+The styled offers complete theming support by exporting a `<ThemeProvider>` wrapper component. This component supplies a theme to all its child components through the `Context API`. Consequently, all styled components in the render tree, regardless of their depth, can access the provided theme.
 
 ```tsx
 type Theme = {
@@ -522,7 +522,7 @@ const style = useStyle(styled => ({
 
 ## Server Side Rendering
 
-The styled supports server-side rendering, complemented by stylesheet rehydration. Essentially, each time your application is rendered on the server, a `ServerStyleSheet` can be created and a provider can be added to your component tree, which accepts styles through a context API.
+The styled supports server-side rendering, complemented by stylesheet rehydration. Essentially, each time your application is rendered on the server, a `ServerStyleSheet` can be created and a provider can be added to your component tree, which accepts styles through a `Context API`. Please note that `sheet.collectStyles()` already contains the provider and you do not need to do anything additional.
 
 ### Rendering to string
 
@@ -535,7 +535,7 @@ const sheet = new ServerStyleSheet();
 try {
   const app = await renderToString(sheet.collectStyles(<App />));
   const tags = sheet.getStyleTags();
-  const mark = '{{%styles%}}' // somewhere in your <head></head>
+  const mark = '__styled__' // somewhere in your <head></head>
   const page = `<!DOCTYPE html>${app}`.replace(mark, tags.join(''));
 
   res.statusCode = 200;

--- a/packages/web-router/src/context/context.tsx
+++ b/packages/web-router/src/context/context.tsx
@@ -7,7 +7,7 @@ import { type Route } from '../create-routes';
 export type ActiveRouteContextValue = {
   location: RouterLocation;
   params: Map<string, string>;
-  activeRoute: Route;
+  route: Route;
 };
 
 const ActiveRouteContext = createContext<ActiveRouteContextValue>(null, { displayName: 'ActiveRoute' });

--- a/packages/web-router/src/create-routes/create-routes.spec.tsx
+++ b/packages/web-router/src/create-routes/create-routes.spec.tsx
@@ -1,12 +1,7 @@
 import { component } from '@dark-engine/core';
-import { resetBrowserHistory } from '@test-utils';
 
 import { Routes } from './types';
 import { createRoutes, resolve } from './create-routes';
-
-afterEach(() => {
-  resetBrowserHistory();
-});
 
 describe('@web-router/create-routes', () => {
   test('can match simple routes correctly', () => {

--- a/packages/web-router/src/create-routes/create-routes.spec.tsx
+++ b/packages/web-router/src/create-routes/create-routes.spec.tsx
@@ -3,7 +3,6 @@ import { resetBrowserHistory } from '@test-utils';
 
 import { Routes } from './types';
 import { createRoutes, resolve } from './create-routes';
-import { ROOT_MARK } from '../constants';
 
 afterEach(() => {
   resetBrowserHistory();
@@ -52,13 +51,14 @@ describe('@web-router/create-routes', () => {
     ];
     const $routes = createRoutes(routes);
 
-    expect(resolve('/', $routes)).toBe(null);
-    expect(resolve('', $routes)).toBe(null);
-    expect(resolve('/xxx', $routes)).toBe(null);
+    expect(() => resolve('/', $routes)).toThrowError();
+    expect(() => resolve('', $routes)).toThrowError();
+    expect(() => resolve('/xxx', $routes)).toThrowError();
     expect(resolve('/second', $routes).path).toBe('second');
-    expect(resolve('/second/1', $routes)).toBe(null);
-    expect(resolve('/first/1/xxx', $routes)).toBe(null);
-    expect(resolve('/some/broken/url', $routes)).toBe(null);
+    expect(() => resolve('/second/1', $routes)).toThrowError();
+    expect(() => resolve('/first/1/xxx', $routes)).toThrowError();
+    expect(() => resolve('/some/broken/url', $routes)).toThrowError();
+    expect(resolve('/first', $routes).path).toBe('first');
   });
 
   test('can match nested routes correctly', () => {
@@ -92,7 +92,7 @@ describe('@web-router/create-routes', () => {
     expect(resolve('/second', $routes).path).toBe('second');
     expect(resolve('/second/a', $routes).path).toBe('second/a');
     expect(resolve('/second/b', $routes).path).toBe('second/b');
-    expect(resolve('/second/b/some/broken/route', $routes)).toBe(null);
+    expect(() => resolve('/second/b/some/broken/route', $routes)).toThrowError();
     expect(resolve('/third', $routes).path).toBe('third');
   });
 
@@ -280,9 +280,9 @@ describe('@web-router/create-routes', () => {
     ];
     const $routes = createRoutes(routes);
 
-    expect(resolve('/', $routes).path).toBe(`${ROOT_MARK}`);
-    expect(resolve('', $routes).path).toBe(`${ROOT_MARK}`);
-    expect(resolve('/broken', $routes).path).toBe(`${ROOT_MARK}`);
+    expect(resolve('/', $routes).path).toBe('');
+    expect(resolve('', $routes).path).toBe('');
+    expect(resolve('/broken', $routes).path).toBe('');
     expect(resolve('/second', $routes).path).toBe(`second`);
     expect(resolve('/third', $routes).path).toBe(`third`);
   });
@@ -724,13 +724,13 @@ describe('@web-router/create-routes', () => {
     ];
     const $routes = createRoutes(routes);
 
-    expect(resolve('/', $routes).path).toBe(`first/${ROOT_MARK}`);
-    expect(resolve('/first', $routes).path).toBe(`first/${ROOT_MARK}`);
+    expect(resolve('/', $routes).path).toBe(`first`);
+    expect(resolve('/first', $routes).path).toBe(`first`);
     expect(resolve('/first/nested', $routes).path).toBe('first/nested');
     expect(resolve('/first/666', $routes).path).toBe(`first/:id`);
-    expect(resolve('/first/666/broken', $routes).path).toBe(`first/${ROOT_MARK}`);
+    expect(resolve('/first/666/broken', $routes).path).toBe(`first`);
     expect(resolve('/second', $routes).path).toBe('second');
     expect(resolve('/third/', $routes).path).toBe('third');
-    expect(resolve('/broken/url', $routes).path).toBe(`first/${ROOT_MARK}`);
+    expect(resolve('/broken/url', $routes).path).toBe(`first`);
   });
 });

--- a/packages/web-router/src/create-routes/create-routes.ts
+++ b/packages/web-router/src/create-routes/create-routes.ts
@@ -1,15 +1,6 @@
 import { type DarkElement, type ComponentFactory, type SlotProps, keyBy, detectIsString } from '@dark-engine/core';
 
-import {
-  pipe,
-  splitBySlash,
-  normalizePath,
-  trimSlashes,
-  detectIsParam,
-  getParamName,
-  sort,
-  reduceSlashes,
-} from '../utils';
+import { pipe, splitBySlash, normalizePath, trimSlashes, detectIsParam, getParamName, sort, join } from '../utils';
 import { SLASH_MARK, WILDCARD_MARK, ROOT_MARK } from '../constants';
 import { CurrentPathContext } from '../context';
 import type { Routes, RouteDescriptor, PathMatchStrategy, Params } from './types';
@@ -42,7 +33,7 @@ class Route {
     this.parent = parent;
     this.children = createRoutes(children, prefixedPath, this);
     this.level = parent ? parent.level + 1 : 0;
-    this.marker = rootPath;
+    this.marker = rootPath === '' ? ROOT_MARK : rootPath;
     this.redirectTo = detectIsString(redirectTo)
       ? {
           path: createPrefixedPath(pathMatch, prefix, createRootPath(redirectTo)),
@@ -57,7 +48,7 @@ class Route {
   }
 
   getPath() {
-    return this.path.replaceAll(new RegExp(`${ROOT_MARK}${SLASH_MARK}?`, 'g'), '');
+    return this.path;
   }
 
   render(): DarkElement {
@@ -76,8 +67,6 @@ class Route {
   }
 }
 
-const trim = (x: string) => trimSlashes(reduceSlashes(x.replaceAll(ROOT_MARK, SLASH_MARK)));
-
 function createRoutes(routes: Routes, prefix = SLASH_MARK, parent: Route = null): Array<Route> {
   const $routes: Array<Route> = [];
 
@@ -88,11 +77,11 @@ function createRoutes(routes: Routes, prefix = SLASH_MARK, parent: Route = null)
   }
 
   if (!parent) {
-    const map = keyBy($routes, x => trim(x.path), true) as Record<string, Route>;
+    const map = keyBy($routes, x => x.path, true) as Record<string, Route>;
 
     for (const $route of $routes) {
       if ($route.redirectTo) {
-        $route.redirectTo.route = map[trim($route.redirectTo.path)] || null;
+        $route.redirectTo.route = map[$route.redirectTo.path] || null;
       }
     }
   }
@@ -100,159 +89,127 @@ function createRoutes(routes: Routes, prefix = SLASH_MARK, parent: Route = null)
   return $routes;
 }
 
-function resolve(path: string, routes: Array<Route>): Route {
-  const route = pipe<Route>(
-    match(path, routes),
-    redirect(),
-    wildcard(path, routes),
-    redirect(),
-    root(),
-    redirect(),
-    canRender(),
-  )();
+function resolve(url: string, routes: Array<Route>): Route | null {
+  const $match = match(url, routes);
+  const $wildcard = wildcard(url, routes);
+  const route = pipe<Route>($match, redirect, $wildcard, redirect, root, redirect, canRender)();
 
   return route;
 }
 
-function match(path: string, routes: Array<Route>) {
-  return (): Route => {
-    const [route] = pipe<Array<Route>>(
-      (routes: Array<Route>) => routes.filter(x => detectIsMatchByFirstStrategy(path, x.path)),
-      (routes: Array<Route>) => routes.filter(x => detectIsMatchBySecondStrategy(path, x.path)),
-    )(routes);
+function match(url: string, routes: Array<Route>) {
+  return () => {
+    const [route] = routes.filter(x => detectIsMatch(url, x.path));
 
     return pick(route);
   };
 }
 
-function redirect() {
-  return (route: Route): Route => {
-    if (route?.redirectTo) return redirect()(route.redirectTo.route);
-    if (route?.parent?.redirectTo) return redirect()(route.parent.redirectTo.route);
+function redirect(route: Route) {
+  if (route?.redirectTo) return redirect(route.redirectTo.route);
+  if (route?.parent?.redirectTo) return redirect(route.parent.redirectTo.route);
 
-    return pick(route);
-  };
+  return pick(route);
 }
 
 function wildcard(path: string, routes: Array<Route>) {
-  return ($route: Route): Route => {
-    if ($route) return $route;
-    const [route] = pipe<Array<Route>>(
+  return (route: Route) => {
+    if (route) return route;
+    const [$route] = pipe<Array<Route>>(
       (routes: Array<Route>) => routes.filter(x => x.marker === WILDCARD_MARK),
       (routes: Array<Route>) => routes.filter(x => detectIsMatchAsWildcard(path, x.path)) || null,
       (routes: Array<Route>) => sort('desc', routes, x => x.level),
     )(routes);
 
-    return pick(route);
+    return pick($route);
   };
 }
 
-function root() {
-  return (route: Route): Route => {
-    const root = route?.children.find(x => x.marker === ROOT_MARK) || route;
+function root(route: Route) {
+  const $route = route?.children.find(x => x.marker === ROOT_MARK);
 
-    return pick(root);
-  };
+  if ($route?.children.length > 0) return root($route);
+
+  return pick($route || route);
 }
 
-function canRender() {
-  return (route: Route): Route => {
-    if (route?.component) return route;
-
-    if (process.env.NODE_ENV !== 'test') {
-      throw new Error('[web-router]: the route was not found or it has no component!');
-    }
-
-    return null;
-  };
+function canRender(route: Route) {
+  if (route?.component) return route;
+  throw new Error('[web-router]: the route was not found or it has no component!');
 }
 
 const pick = (route: Route): Route | null => route || null;
 
-function detectIsMatchByFirstStrategy(urlPath: string, routePath: string): boolean {
+function detectIsMatch(url: string, path: string) {
   const matcher = createMatcher({
-    space: (_, b) => b,
-    skip: ({ isRoot, isParam }) => isRoot || isParam,
-  });
-
-  return matcher(urlPath, routePath);
-}
-
-function detectIsMatchBySecondStrategy(urlPath: string, routePath: string): boolean {
-  const matcher = createMatcher({
-    space: a => a,
+    space: (a, b) => Math.max(a.length, b.length),
     skip: ({ isParam }) => isParam,
   });
 
-  return matcher(urlPath, routePath);
+  return matcher(url, path);
 }
 
-function detectIsMatchAsWildcard(urlPath: string, routePath: string): boolean {
+function detectIsMatchAsWildcard(url: string, path: string) {
   const matcher = createMatcher({
-    space: (_, b) => b,
-    skip: ({ isRoot, isParam, isWildcard }) => isRoot || isParam || isWildcard,
+    space: (_, b) => b.length,
+    skip: ({ isParam, isWildcard }) => isParam || isWildcard,
   });
 
-  return matcher(urlPath, routePath);
+  return matcher(url, path);
 }
 
 type CreateMatcherOptions = {
-  space: (a: Array<string>, b: Array<string>) => Array<string>;
+  space: (a: Array<string>, b: Array<string>) => number;
   skip: (options: SkipOptions) => boolean;
 };
 
 type SkipOptions = {
-  isRoot: boolean;
   isWildcard: boolean;
   isParam: boolean;
 };
 
 function createMatcher(options: CreateMatcherOptions) {
   const { space, skip } = options;
-  return (urlPath: string, routePath: string) => {
-    const sUrlPath = splitBySlash(urlPath);
-    const sRoutePath = splitBySlash(routePath);
 
-    for (let i = 0; i < space(sUrlPath, sRoutePath).length; i++) {
-      const segment = sRoutePath[i];
-      const isRoot = segment === ROOT_MARK;
+  return (url: string, path: string) => {
+    const [a, b] = split(url, path);
+
+    for (let i = 0; i < space(a, b); i++) {
+      const segment = b[i];
       const isWildcard = segment === WILDCARD_MARK;
       const isParam = detectIsParam(segment);
 
-      if (segment !== sUrlPath[i] && !skip({ isRoot, isWildcard, isParam })) return false;
+      if (segment !== a[i] && !skip({ isWildcard, isParam })) return false;
     }
 
     return true;
   };
 }
 
-function mergePathes(urlPath: string, routePath: string) {
-  const sUrl = splitBySlash(urlPath);
-  const sRoute = splitBySlash(routePath);
+function mergePaths(url: string, path: string) {
+  const [a, b] = split(url, path);
   const parts: Array<string> = [];
 
-  for (let i = 0; i < sRoute.length; i++) {
-    const isParam = detectIsParam(sRoute[i]);
+  for (let i = 0; i < b.length; i++) {
+    const isParam = detectIsParam(b[i]);
 
     if (isParam) {
-      const param = sUrl[i] || 'null';
+      const param = a[i] || 'null';
 
       parts.push(param);
     } else {
-      parts.push(sRoute[i]);
+      parts.push(b[i]);
     }
   }
 
-  let path = normalizePath(parts.join(SLASH_MARK));
+  let $path = normalizePath(parts.join(SLASH_MARK));
 
-  if (path[0] !== SLASH_MARK) {
-    path = SLASH_MARK + path;
+  if ($path[0] !== SLASH_MARK) {
+    $path = join(SLASH_MARK, $path);
   }
 
-  return path;
+  return $path;
 }
-
-const createRootPath = (path: string) => (path === SLASH_MARK || path === '' ? ROOT_MARK : path);
 
 function createPrefixedPath(pathMatch: PathMatchStrategy, prefix: string, path: string) {
   const $prefix = pathMatch === 'prefix' ? normalizePath(prefix) + SLASH_MARK : '';
@@ -260,64 +217,21 @@ function createPrefixedPath(pathMatch: PathMatchStrategy, prefix: string, path: 
   return trimSlashes(normalizePath($prefix ? `${$prefix}${path}` : path));
 }
 
-function getParamsMap(path: string, route: Route): Params {
-  const sPathname = splitBySlash(path);
-  const sPath = splitBySlash(route.path);
+function getParamsMap(url: string, route: Route): Params {
+  const [a, b] = split(url, route.path);
   const map = new Map();
 
-  for (let i = 0; i < sPath.length; i++) {
-    if (detectIsParam(sPath[i])) {
-      map.set(getParamName(sPath[i]), sPathname[i]);
+  for (let i = 0; i < b.length; i++) {
+    if (detectIsParam(b[i])) {
+      map.set(getParamName(b[i]), a[i]);
     }
   }
 
   return map;
 }
 
-function resolve2(url: string, routes: Array<Route>): Route | null {
-  const a = splitBySlash(url);
-
-  let [route] = routes.filter(x => {
-    const path = reduceSlashes(x.path.replaceAll(ROOT_MARK, SLASH_MARK));
-    const b = splitBySlash(path);
-    const max = Math.max(a.length, b.length);
-
-    for (let i = 0; i < max; i++) {
-      const part1 = a[i];
-      const part2 = b[i];
-
-      if (detectIsParam(part2)) continue;
-      if (part1 !== part2) return false;
-    }
-
-    return true;
-  });
-
-  if (route && route.redirectTo) {
-    route = redirect()(route);
-  }
-
-  if (!route) {
-    let wild = wildcard(url, routes)(route);
-
-    if (wild && wild.redirectTo) {
-      wild = redirect()(wild);
-    }
-
-    route = wild;
-  }
-
-  route = root()(route);
-
-  if (route && route.redirectTo) {
-    route = redirect()(route);
-  }
-
-  return route;
-}
-
 function resolveRoute(url: string, routes: Array<Route>) {
-  const activeRoute = resolve2(url, routes);
+  const activeRoute = resolve(url, routes);
   const slot = activeRoute ? activeRoute.render() : null;
   const params = activeRoute ? getParamsMap(url, activeRoute) : null;
   const value = { activeRoute, slot, params };
@@ -325,4 +239,8 @@ function resolveRoute(url: string, routes: Array<Route>) {
   return value;
 }
 
-export { type Route, createRoutes, resolve, resolveRoute, mergePathes };
+const createRootPath = (path: string) => (path === SLASH_MARK ? '' : path);
+
+const split = (url: string, path: string) => [splitBySlash(url), splitBySlash(path)];
+
+export { type Route, createRoutes, resolve, resolveRoute, mergePaths };

--- a/packages/web-router/src/create-routes/create-routes.ts
+++ b/packages/web-router/src/create-routes/create-routes.ts
@@ -230,11 +230,17 @@ function getParamsMap(url: string, route: Route): Params {
   return map;
 }
 
+type ResolveRouteValue = {
+  route: Route;
+  slot: DarkElement;
+  params: Params;
+};
+
 function resolveRoute(url: string, routes: Array<Route>) {
   const route = resolve(url, routes);
   const slot = route.render();
   const params = getParamsMap(url, route);
-  const value = { activeRoute: route, slot, params };
+  const value: ResolveRouteValue = { route, slot, params };
 
   return value;
 }
@@ -243,4 +249,8 @@ const createRootPath = (path: string) => (path === SLASH_MARK ? '' : path);
 
 const split = (url: string, path: string) => [splitBySlash(url), splitBySlash(path)];
 
-export { type Route, createRoutes, resolve, resolveRoute, mergePaths };
+const merge = (url: string, route: Route, s: string, h: string) => join(mergePaths(url, route.getPath()), s, h);
+
+const detectIsWildcard = (route: Route) => route.marker === WILDCARD_MARK;
+
+export { type Route, createRoutes, resolve, resolveRoute, mergePaths, merge, detectIsWildcard };

--- a/packages/web-router/src/create-routes/create-routes.ts
+++ b/packages/web-router/src/create-routes/create-routes.ts
@@ -231,10 +231,10 @@ function getParamsMap(url: string, route: Route): Params {
 }
 
 function resolveRoute(url: string, routes: Array<Route>) {
-  const activeRoute = resolve(url, routes);
-  const slot = activeRoute ? activeRoute.render() : null;
-  const params = activeRoute ? getParamsMap(url, activeRoute) : null;
-  const value = { activeRoute, slot, params };
+  const route = resolve(url, routes);
+  const slot = route.render();
+  const params = getParamsMap(url, route);
+  const value = { activeRoute: route, slot, params };
 
   return value;
 }

--- a/packages/web-router/src/index.ts
+++ b/packages/web-router/src/index.ts
@@ -1,5 +1,5 @@
+export { type Routes, type PathMatchStrategy } from './create-routes';
 export { type RouterRef, Router } from './router';
-export { type Routes } from './create-routes';
 export { useLocation } from './use-location';
 export { RouterLink } from './router-link';
 export { useHistory } from './use-history';

--- a/packages/web-router/src/index.ts
+++ b/packages/web-router/src/index.ts
@@ -1,4 +1,4 @@
-export { type Routes, type PathMatchStrategy } from './create-routes';
+export { type Routes } from './create-routes';
 export { type RouterRef, Router } from './router';
 export { useLocation } from './use-location';
 export { RouterLink } from './router-link';

--- a/packages/web-router/src/router-link/router-link.spec.tsx
+++ b/packages/web-router/src/router-link/router-link.spec.tsx
@@ -10,7 +10,6 @@ import { RouterLink } from './router-link';
 let { host, render } = createBrowserEnv();
 
 beforeEach(() => {
-  jest.useFakeTimers();
   ({ host, render } = createBrowserEnv());
 });
 
@@ -68,7 +67,6 @@ describe('@web-router/router-link', () => {
     });
 
     render(<App />);
-    jest.runAllTimers();
     expect(host.innerHTML).toBe(content('', replacer));
 
     const link1 = host.querySelector('a[href="/first"]');
@@ -111,7 +109,6 @@ describe('@web-router/router-link', () => {
     });
 
     render(<App />);
-    jest.runAllTimers();
     expect(host.innerHTML).toBe(`<a href="/" class="my-link custom-active-link">first</a>`);
   });
 
@@ -144,7 +141,6 @@ describe('@web-router/router-link', () => {
     });
 
     render(<App />);
-    jest.runAllTimers();
     expect(host.innerHTML).toBe(`<a href="/" class="${ACTIVE_LINK_CLASSNAME}">first</a>`);
 
     click(host.querySelector('a'));

--- a/packages/web-router/src/router-link/router-link.spec.tsx
+++ b/packages/web-router/src/router-link/router-link.spec.tsx
@@ -42,6 +42,10 @@ describe('@web-router/router-link', () => {
         path: 'third',
         component: component(() => <div>third</div>),
       },
+      {
+        path: '**',
+        component: component(() => null),
+      },
     ];
 
     const App = component(() => {

--- a/packages/web-router/src/router/router.spec.tsx
+++ b/packages/web-router/src/router/router.spec.tsx
@@ -1,6 +1,6 @@
 import { type DarkElement, type MutableRef, component, useRef } from '@dark-engine/core';
 
-import { createBrowserEnv, replacer, resetBrowserHistory } from '@test-utils';
+import { createBrowserEnv, replacer, resetBrowserHistory, sleep } from '@test-utils';
 import { type Routes } from '../create-routes';
 import { type RouterRef, Router } from './router';
 
@@ -8,21 +8,15 @@ type AppProps = {
   url: string;
 };
 
-let { host, render: $render, unmount } = createBrowserEnv();
+let { host, render, unmount } = createBrowserEnv();
 
 beforeEach(() => {
-  jest.useFakeTimers();
-  ({ host, render: $render, unmount } = createBrowserEnv());
+  ({ host, render, unmount } = createBrowserEnv());
 });
 
 afterEach(() => {
   resetBrowserHistory();
 });
-
-const render = (element: DarkElement) => {
-  $render(element);
-  jest.runAllTimers();
-};
 
 describe('@web-router/router', () => {
   test('can render simple routes correctly', () => {
@@ -1006,7 +1000,7 @@ describe('@web-router/router', () => {
     expect(host.innerHTML).toBe(`<first><div>root</div></first>`);
   });
 
-  test('a history updates correctly with wildcard routing', () => {
+  test('a history updates correctly with wildcard routing', async () => {
     let routerRef: MutableRef<RouterRef> = null;
     const routes: Routes = [
       {
@@ -1044,7 +1038,7 @@ describe('@web-router/router', () => {
     render(<App />);
 
     routerRef.current.navigateTo('/broken/');
-    jest.runAllTimers();
+    await sleep(0);
     expect(host.innerHTML).toBe(`<div>404</div>`);
     expect(location.href).toBe('http://localhost/broken/');
   });

--- a/packages/web-router/src/router/router.spec.tsx
+++ b/packages/web-router/src/router/router.spec.tsx
@@ -8,11 +8,11 @@ type AppProps = {
   url: string;
 };
 
-let { host, render: $render } = createBrowserEnv();
+let { host, render: $render, unmount } = createBrowserEnv();
 
 beforeEach(() => {
   jest.useFakeTimers();
-  ({ host, render: $render } = createBrowserEnv());
+  ({ host, render: $render, unmount } = createBrowserEnv());
 });
 
 afterEach(() => {
@@ -72,6 +72,10 @@ describe('@web-router/router', () => {
       {
         path: 'third',
         component: component(() => <div>third</div>),
+      },
+      {
+        path: '**',
+        component: component(() => null),
       },
     ];
 
@@ -154,9 +158,9 @@ describe('@web-router/router', () => {
     render(<App url='/second/b' />);
     expect(host.innerHTML).toBe(`<second><div>b</div></second>`);
 
-    render(<App url='/second/b/some/broken/route' />);
-    expect(host.innerHTML).toBe(replacer);
+    expect(() => render(<App url='/second/b/some/broken/route' />)).toThrowError();
 
+    unmount();
     render(<App url='/third' />);
     expect(host.innerHTML).toBe(`<div>third</div>`);
   });

--- a/packages/web-router/src/router/router.tsx
+++ b/packages/web-router/src/router/router.tsx
@@ -3,7 +3,6 @@ import {
   type MutableRef,
   component,
   useMemo,
-  useEffect,
   useLayoutEffect,
   useState,
   forwardRef,
@@ -73,7 +72,7 @@ const Router = forwardRef<RouterProps, RouterRef>(
         };
       }, []);
 
-      useEffect(() => {
+      useLayoutEffect(() => {
         if (!activeRoute || activeRoute.marker === WILDCARD_MARK) return;
         const url1 = join(url, search, hash);
         const url2 = join(mergePaths(url, activeRoute.getPath()), search, hash);

--- a/packages/web-router/src/router/router.tsx
+++ b/packages/web-router/src/router/router.tsx
@@ -70,8 +70,9 @@ const Router = forwardRef<RouterProps, RouterRef>(
 
           if (isDifferent || prevURL !== nextURL) {
             const href = join(protocol, PROTOCOL_MARK, host, nextURL);
+            const location = createRouterLocation(href);
 
-            setLocation(createRouterLocation(href));
+            setLocation(location);
             isDifferent && !detectIsWildcard(nextRoute) && history.replace(nextURL);
           }
         });

--- a/packages/web-router/src/router/router.tsx
+++ b/packages/web-router/src/router/router.tsx
@@ -15,7 +15,7 @@ import { SLASH_MARK, PROTOCOL_MARK, WILDCARD_MARK } from '../constants';
 import { normalizePath, join } from '../utils';
 import { createRouterHistory } from '../history';
 import { type RouterLocation, createRouterLocation } from '../location';
-import { type Routes, createRoutes, resolveRoute, mergePathes } from '../create-routes';
+import { type Routes, createRoutes, resolveRoute, mergePaths } from '../create-routes';
 import {
   type RouterHistoryContextValue,
   type ActiveRouteContextValue,
@@ -38,20 +38,17 @@ export type RouterRef = {
 
 const Router = forwardRef<RouterProps, RouterRef>(
   component(
-    ({ url, baseURL = SLASH_MARK, routes: sourceRoutes, slot }, ref) => {
+    ({ url: fullURL, baseURL = SLASH_MARK, routes: sourceRoutes, slot }, ref) => {
       if (useActiveRouteContext()) throw new Error(`[web-router]: the parent active route's context detected!`);
-      const sourceURL = url || window.location.href;
+      const sourceURL = fullURL || window.location.href;
       const [location, setLocation] = useState(() => createRouterLocation(sourceURL));
       const history = useMemo(() => createRouterHistory(sourceURL), []);
       const routes = useMemo(() => createRoutes(sourceRoutes, normalizePath(baseURL)), []);
-      const { protocol, host, pathname: path, search, hash } = location;
-      const { activeRoute, slot: $slot, params } = resolveRoute(path, routes);
+      const { protocol, host, pathname: url, search, hash } = location;
+      const { activeRoute, slot: $slot, params } = resolveRoute(url, routes);
       const scope = useMemo(() => ({ location }), []);
       const historyContext = useMemo<RouterHistoryContextValue>(() => ({ history }), []);
-      const routerContext = useMemo<ActiveRouteContextValue>(
-        () => ({ location, activeRoute, params }),
-        [path, search, hash],
-      );
+      const routerContext = useMemo<ActiveRouteContextValue>(() => ({ location, activeRoute, params }), [location]);
 
       scope.location = location;
 
@@ -76,13 +73,13 @@ const Router = forwardRef<RouterProps, RouterRef>(
 
       useEffect(() => {
         if (!activeRoute || activeRoute.marker === WILDCARD_MARK) return;
-        const url = join(path, search, hash);
-        const $url = join(mergePathes(path, activeRoute.getPath()), search, hash);
+        const url1 = join(url, search, hash);
+        const url2 = join(mergePaths(url, activeRoute.getPath()), search, hash);
 
-        if (url !== $url) {
-          history.replace($url);
+        if (url1 !== url2) {
+          history.replace(url2);
         }
-      }, [path, search, hash]);
+      }, [url, search, hash]);
 
       useImperativeHandle(ref as MutableRef<RouterRef>, () => ({
         navigateTo: (url: string) => nextTick(() => history.push(url)),

--- a/packages/web-router/src/router/router.tsx
+++ b/packages/web-router/src/router/router.tsx
@@ -62,7 +62,9 @@ const Router = forwardRef<RouterProps, RouterRef>(
         const unsubscribe = history.subscribe(url => {
           const href = join(protocol, PROTOCOL_MARK, host, url);
 
-          setLocation(createRouterLocation(href));
+          if (href !== scope.location.url) {
+            setLocation(createRouterLocation(href));
+          }
         });
 
         return () => {
@@ -79,7 +81,7 @@ const Router = forwardRef<RouterProps, RouterRef>(
         if (url1 !== url2) {
           history.replace(url2);
         }
-      }, [url, search, hash]);
+      }, [location]);
 
       useImperativeHandle(ref as MutableRef<RouterRef>, () => ({
         navigateTo: (url: string) => nextTick(() => history.push(url)),

--- a/packages/web-router/src/use-history/use-history.spec.tsx
+++ b/packages/web-router/src/use-history/use-history.spec.tsx
@@ -9,7 +9,6 @@ import { RouterHistory } from '../history';
 let { host, render } = createBrowserEnv();
 
 beforeEach(() => {
-  jest.useFakeTimers();
   ({ host, render } = createBrowserEnv());
 });
 
@@ -44,28 +43,23 @@ describe('@web-router/use-history', () => {
     });
 
     render(<App />);
-    jest.runAllTimers();
     expect(history).toBeInstanceOf(RouterHistory);
     expect(host.innerHTML).toBe(`<div>root</div>`);
     expect(location.href).toBe('http://localhost/');
 
     history.push('/second/');
-    jest.runAllTimers();
     expect(host.innerHTML).toBe(`<div>second</div>`);
     expect(location.href).toBe('http://localhost/second');
 
     history.push('/third/');
-    jest.runAllTimers();
     expect(host.innerHTML).toBe(`<div>third</div>`);
     expect(location.href).toBe('http://localhost/third');
 
     history.push('/second');
-    jest.runAllTimers();
     expect(host.innerHTML).toBe(`<div>second</div>`);
     expect(location.href).toBe('http://localhost/second');
 
     history.push('/second');
-    jest.runAllTimers();
     expect(host.innerHTML).toBe(`<div>second</div>`);
     expect(location.href).toBe('http://localhost/second');
   });

--- a/packages/web-router/src/use-history/use-history.spec.tsx
+++ b/packages/web-router/src/use-history/use-history.spec.tsx
@@ -9,6 +9,7 @@ import { RouterHistory } from '../history';
 let { host, render } = createBrowserEnv();
 
 beforeEach(() => {
+  jest.useFakeTimers();
   ({ host, render } = createBrowserEnv());
 });
 
@@ -48,18 +49,22 @@ describe('@web-router/use-history', () => {
     expect(location.href).toBe('http://localhost/');
 
     history.push('/second/');
+    jest.runAllTimers();
     expect(host.innerHTML).toBe(`<div>second</div>`);
     expect(location.href).toBe('http://localhost/second');
 
     history.push('/third/');
+    jest.runAllTimers();
     expect(host.innerHTML).toBe(`<div>third</div>`);
     expect(location.href).toBe('http://localhost/third');
 
     history.push('/second');
+    jest.runAllTimers();
     expect(host.innerHTML).toBe(`<div>second</div>`);
     expect(location.href).toBe('http://localhost/second');
 
     history.push('/second');
+    jest.runAllTimers();
     expect(host.innerHTML).toBe(`<div>second</div>`);
     expect(location.href).toBe('http://localhost/second');
   });

--- a/packages/web-router/src/use-location/use-location.spec.tsx
+++ b/packages/web-router/src/use-location/use-location.spec.tsx
@@ -11,7 +11,6 @@ import { useLocation } from './use-location';
 let { host, render } = createBrowserEnv();
 
 beforeEach(() => {
-  jest.useFakeTimers();
   ({ host, render } = createBrowserEnv());
 });
 
@@ -49,14 +48,12 @@ describe('@web-router/use-location', () => {
     });
 
     render(<App />);
-    jest.runAllTimers();
     expect(location).toBeInstanceOf(RouterLocation);
     expect(location.pathname).toBe('/');
     expect(location.key).toBeTruthy();
     expect(host.innerHTML).toBe(`<div>root</div>`);
 
     history.push('/second');
-    jest.runAllTimers();
     expect(host.innerHTML).toBe(`<div>second</div>`);
     expect(location).toBeInstanceOf(RouterLocation);
     expect(location.pathname).toBe('/second');

--- a/packages/web-router/src/use-location/use-location.ts
+++ b/packages/web-router/src/use-location/use-location.ts
@@ -1,11 +1,11 @@
 import { useActiveRouteContext, checkContextValue } from '../context';
 
 function useLocation() {
-  const activeRoute = useActiveRouteContext();
+  const active = useActiveRouteContext();
 
-  checkContextValue(activeRoute);
+  checkContextValue(active);
 
-  return activeRoute.location;
+  return active.location;
 }
 
 export { useLocation };

--- a/packages/web-router/src/use-match/use-match.spec.tsx
+++ b/packages/web-router/src/use-match/use-match.spec.tsx
@@ -10,7 +10,6 @@ import { useMatch, type Match } from './use-match';
 let { host, render } = createBrowserEnv();
 
 beforeEach(() => {
-  jest.useFakeTimers();
   ({ host, render } = createBrowserEnv());
 });
 
@@ -47,14 +46,12 @@ describe('@web-router/use-match', () => {
     });
 
     render(<App />);
-    jest.runAllTimers();
     expect(match).toBeTruthy();
     expect(match.path).toBe('');
     expect(match.url).toBe('');
     expect(host.innerHTML).toMatchInlineSnapshot(`"<div>root</div>"`);
 
     history.push('/second/10');
-    jest.runAllTimers();
     expect(host.innerHTML).toMatchInlineSnapshot(`"<div>second</div>"`);
     expect(match).toBeTruthy();
     expect(match.path).toBe('second/:id');
@@ -97,21 +94,18 @@ describe('@web-router/use-match', () => {
     });
 
     render(<App />);
-    jest.runAllTimers();
     expect(match).toBeTruthy();
     expect(match.path).toBe('');
     expect(match.url).toBe('');
     expect(host.innerHTML).toMatchInlineSnapshot(`"<div>root</div>"`);
 
     history.push('/first');
-    jest.runAllTimers();
     expect(host.innerHTML).toMatchInlineSnapshot(`"<div>first</div>"`);
     expect(match).toBeTruthy();
     expect(match.path).toBe('first');
     expect(match.url).toBe('/first');
 
     history.push('/second');
-    jest.runAllTimers();
     expect(host.innerHTML).toMatchInlineSnapshot(`"<div>second</div>"`);
     expect(match).toBeTruthy();
     expect(match.path).toBe('second');
@@ -154,21 +148,18 @@ describe('@web-router/use-match', () => {
     });
 
     render(<App />);
-    jest.runAllTimers();
     expect(match).toBeTruthy();
     expect(match.path).toBe('');
     expect(match.url).toBe('');
     expect(host.innerHTML).toMatchInlineSnapshot(`"<div>root</div>"`);
 
     history.push('/first/');
-    jest.runAllTimers();
     expect(host.innerHTML).toMatchInlineSnapshot(`"<div>first</div>"`);
     expect(match).toBeTruthy();
     expect(match.path).toBe('first');
     expect(match.url).toBe('/first');
 
     history.push('/second/');
-    jest.runAllTimers();
     expect(host.innerHTML).toMatchInlineSnapshot(`"<div>second</div>"`);
     expect(match).toBeTruthy();
     expect(match.path).toBe('second');
@@ -211,21 +202,18 @@ describe('@web-router/use-match', () => {
     });
 
     render(<App />);
-    jest.runAllTimers();
     expect(match).toBeTruthy();
     expect(match.path).toBe('');
     expect(match.url).toBe('');
     expect(host.innerHTML).toMatchInlineSnapshot(`"<div>root</div>"`);
 
     history.push('/first');
-    jest.runAllTimers();
     expect(host.innerHTML).toMatchInlineSnapshot(`"<div>first</div>"`);
     expect(match).toBeTruthy();
     expect(match.path).toBe('first');
     expect(match.url).toBe('/first');
 
     history.push('/second');
-    jest.runAllTimers();
     expect(host.innerHTML).toMatchInlineSnapshot(`"<div>second</div>"`);
     expect(match).toBeTruthy();
     expect(match.path).toBe('second');
@@ -274,10 +262,8 @@ describe('@web-router/use-match', () => {
     });
 
     render(<App />);
-    jest.runAllTimers();
 
     history.push('/second/child');
-    jest.runAllTimers();
     expect(host.innerHTML).toMatchInlineSnapshot(`"<div>second: <div>child</div></div>"`);
     expect(match1).toBeTruthy();
     expect(match1.path).toBe('second');
@@ -340,10 +326,8 @@ describe('@web-router/use-match', () => {
     });
 
     render(<App />);
-    jest.runAllTimers();
 
     history.push('/second/child/another');
-    jest.runAllTimers();
     expect(host.innerHTML).toMatchInlineSnapshot(`"<div>second: <div>child: <div>another</div></div></div>"`);
     expect(match1).toBeTruthy();
     expect(match1.path).toBe('second');
@@ -409,10 +393,8 @@ describe('@web-router/use-match', () => {
     });
 
     render(<App />);
-    jest.runAllTimers();
 
     history.push('/second/child/10/another');
-    jest.runAllTimers();
     expect(host.innerHTML).toMatchInlineSnapshot(`"<div>second: <div>child: <div>another</div></div></div>"`);
     expect(match1).toBeTruthy();
     expect(match1.path).toBe('second');
@@ -425,7 +407,6 @@ describe('@web-router/use-match', () => {
     expect(match3.url).toBe('/second/child/10/another');
 
     history.push('/second/child/20/another?q=xxx');
-    jest.runAllTimers();
     expect(host.innerHTML).toMatchInlineSnapshot(`"<div>second: <div>child: <div>another</div></div></div>"`);
     expect(match1).toBeTruthy();
     expect(match1.path).toBe('second');

--- a/packages/web-router/src/use-match/use-match.ts
+++ b/packages/web-router/src/use-match/use-match.ts
@@ -9,12 +9,12 @@ export type Match = {
 };
 
 function useMatch() {
-  const activeRoute = useActiveRouteContext();
-  checkContextValue(activeRoute);
+  const active = useActiveRouteContext();
+  checkContextValue(active);
   const path = useCurrentPathContext();
   const {
     location: { pathname: url },
-  } = activeRoute;
+  } = active;
   const $url = useMemo(() => (path ? mergePaths(url, path) : ''), [url, path]);
   const value: Match = { path, url: $url };
 

--- a/packages/web-router/src/use-match/use-match.ts
+++ b/packages/web-router/src/use-match/use-match.ts
@@ -1,7 +1,7 @@
 import { useMemo } from '@dark-engine/core';
 
 import { useActiveRouteContext, useCurrentPathContext, checkContextValue } from '../context';
-import { mergePathes } from '../create-routes';
+import { mergePaths } from '../create-routes';
 
 export type Match = {
   path: string;
@@ -11,12 +11,12 @@ export type Match = {
 function useMatch() {
   const activeRoute = useActiveRouteContext();
   checkContextValue(activeRoute);
-  const routePath = useCurrentPathContext();
+  const path = useCurrentPathContext();
   const {
-    location: { pathname: urlPath },
+    location: { pathname: url },
   } = activeRoute;
-  const url = useMemo(() => (routePath ? mergePathes(urlPath, routePath) : ''), [urlPath, routePath]);
-  const value: Match = { path: routePath, url };
+  const $url = useMemo(() => (path ? mergePaths(url, path) : ''), [url, path]);
+  const value: Match = { path, url: $url };
 
   return value;
 }

--- a/packages/web-router/src/use-params/use-params.spec.tsx
+++ b/packages/web-router/src/use-params/use-params.spec.tsx
@@ -10,7 +10,6 @@ import { useParams } from './use-params';
 let { host, render } = createBrowserEnv();
 
 beforeEach(() => {
-  jest.useFakeTimers();
   ({ host, render } = createBrowserEnv());
 });
 
@@ -73,19 +72,15 @@ describe('@web-router/use-params', () => {
     });
 
     render(<App />);
-    jest.runAllTimers();
     expect(host.innerHTML).toBe(`<div>root</div>`);
 
     history.push('/first/1');
-    jest.runAllTimers();
     expect(host.innerHTML).toBe(`<div>first: 1</div>`);
 
     history.push('/second/2');
-    jest.runAllTimers();
     expect(host.innerHTML).toBe(`<div>second: 2${replacer}</div>`);
 
     history.push('/second/2/a/3');
-    jest.runAllTimers();
     expect(host.innerHTML).toBe(`<div>second: 2<div>a: 2|3</div></div>`);
   });
 });

--- a/packages/web-router/src/use-params/use-params.ts
+++ b/packages/web-router/src/use-params/use-params.ts
@@ -2,11 +2,11 @@ import { useActiveRouteContext, checkContextValue } from '../context';
 import { type Params } from '../create-routes';
 
 function useParams(): Params {
-  const value = useActiveRouteContext();
+  const active = useActiveRouteContext();
 
-  checkContextValue(value);
+  checkContextValue(active);
 
-  return value.params;
+  return active.params;
 }
 
 export { Params, useParams };


### PR DESCRIPTION
Adds the ability to resolve routes like ([linked issue](https://github.com/atellmer/dark/issues/53))

```tsx
const routes: Routes = [
  ...['en', 'it', 'fr'].map(lang => ({
    path: lang,
    component: Root,
    children: [
      {
        path: 'contacts',
        component: Contacts,
      },
      {
        path: '**',
        pathMatch: 'full',
        redirectTo: '/not-found',
      },
    ],
  })),
  {
    path: '',
    component: Root,
    children: [
      {
        path: 'contacts',
        component: Contacts,
      },
      {
        path: 'not-found',
        component: NotFound,
      },
    ],
  },
  {
    path: '**',
    redirectTo: 'not-found',
  },
];
```