### PR TITLE
Adds a new Context API 

### DIFF
--- a/examples/theme-context/index.tsx
+++ b/examples/theme-context/index.tsx
@@ -79,14 +79,14 @@ const App = component(() => {
   return (
     <>
       <GlobalStyle />
-      <ThemeContext.Provider value={context}>
+      <ThemeContext value={context}>
         <Body />
         <Root>
           <StaticLayout>
             <DarkModeSwitch />
           </StaticLayout>
         </Root>
-      </ThemeContext.Provider>
+      </ThemeContext>
     </>
   );
 });

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -699,10 +699,10 @@ const App = component(() => {
   const handleToggle = () => setTheme(x => (x === 'dark' ? 'light' : 'dark'));
 
   return (
-    <ThemeContext.Provider value={theme}>
+    <ThemeContext value={theme}>
       <CurrentTheme />
       <button onClick={handleToggle}>Toggle: {theme}</button>
-    </ThemeContext.Provider>
+    </ThemeContext>
   );
 });
 ```

--- a/packages/core/src/context/context.ts
+++ b/packages/core/src/context/context.ts
@@ -84,7 +84,7 @@ export type ContexProps<T> = {
 } & SlotProps &
   KeyProps;
 
-export type Context<T> = ComponentFactory<ContexProps<T>> & { defaultValue: T };
+export type Context<T = {}> = ComponentFactory<ContexProps<T>> & { defaultValue: T };
 
 export type ContextProvider<T = unknown> = {
   value: T;

--- a/packages/data/src/client/client.ts
+++ b/packages/data/src/client/client.ts
@@ -47,7 +47,7 @@ type DataClientProviderProps = {
 
 const DataClientProvider = component<DataClientProviderProps>(({ client, slot }) => {
   if (useClient()) illegal('Illegal nested data client provider!');
-  return DataClientContext.Provider({ value: client, slot });
+  return DataClientContext({ value: client, slot });
 });
 
 export { DataClient, useClient, useApi, useCache, DataClientProvider };

--- a/packages/native-navigation/src/navigation-container/navigation-container.tsx
+++ b/packages/native-navigation/src/navigation-container/navigation-container.tsx
@@ -150,7 +150,7 @@ const NavigationContainer = component<NavigationContainerProps>(
     const hasActionBar = detectIsFunction(renderActionBar);
 
     return (
-      <NavigationContext.Provider value={contextValue}>
+      <NavigationContext value={contextValue}>
         <Frame>
           <Page actionBarHidden={!hasActionBar}>
             {hasActionBar && renderActionBar({ pathname, goBack: back })}
@@ -160,7 +160,7 @@ const NavigationContainer = component<NavigationContainerProps>(
         <Frame ref={frameRef} hidden>
           <Page ref={pageRef} actionBarHidden />
         </Frame>
-      </NavigationContext.Provider>
+      </NavigationContext>
     );
   },
   { displayName: 'NavigationContainer' },

--- a/packages/native-navigation/src/stack-navigator/stack-navigator.tsx
+++ b/packages/native-navigation/src/stack-navigator/stack-navigator.tsx
@@ -121,9 +121,9 @@ const Screen = component<StackScreenProps>(
     const isVisited = detectIsVisited(visitedMap, pathname);
 
     return (
-      <ScreenNavigatorContext.Provider value={contextValue}>
+      <ScreenNavigatorContext value={contextValue}>
         {isVisited && (detectIsFunction(slot) ? slot() : component())}
-      </ScreenNavigatorContext.Provider>
+      </ScreenNavigatorContext>
     );
   },
   {

--- a/packages/native-navigation/src/tab-navigator/tab-navigator.tsx
+++ b/packages/native-navigation/src/tab-navigator/tab-navigator.tsx
@@ -70,7 +70,7 @@ const Navigator = component<TabNavigatorProps>(
     });
 
     return (
-      <TabNavigatorContext.Provider value={contextValue}>
+      <TabNavigatorContext value={contextValue}>
         <AbsoluteLayout ref={layoutRef} onLayoutChanged={handleLayoutChange}>
           <StackLayout width='100%' height='100%'>
             {descriptorKeys.length > 0 && (
@@ -98,7 +98,7 @@ const Navigator = component<TabNavigatorProps>(
             {slot}
           </FlexboxLayout>
         </AbsoluteLayout>
-      </TabNavigatorContext.Provider>
+      </TabNavigatorContext>
     );
   },
   { displayName: 'TabNavigator.Root' },

--- a/packages/styled/src/server/manager.ts
+++ b/packages/styled/src/server/manager.ts
@@ -49,7 +49,7 @@ type ThemeProviderProps = {
 };
 
 const ManagerProvider = component<ThemeProviderProps>(({ manager, slot }) => {
-  return ManagerContext.Provider({ value: manager, slot });
+  return ManagerContext({ value: manager, slot });
 });
 
 export { Manager, useManager, ManagerProvider };

--- a/packages/styled/src/theme/theme.ts
+++ b/packages/styled/src/theme/theme.ts
@@ -26,7 +26,7 @@ type ThemeProviderProps = {
 };
 
 const ThemeProvider = component<ThemeProviderProps>(({ theme, slot }) => {
-  return ThemeContext.Provider({ value: theme, slot });
+  return ThemeContext({ value: theme, slot });
 });
 
 export { ThemeProvider, useTheme };

--- a/packages/web-router/src/create-routes/create-routes.ts
+++ b/packages/web-router/src/create-routes/create-routes.ts
@@ -72,7 +72,7 @@ class Route {
       const component = factory({ slot });
 
       component.displayName = `Route(${nextRoute.getPath()})`;
-      slot = CurrentPathContext.Provider({ value, slot: [component] });
+      slot = CurrentPathContext({ value, slot: [component] });
       nextRoute = nextRoute.parent;
     }
 

--- a/packages/web-router/src/router/router.tsx
+++ b/packages/web-router/src/router/router.tsx
@@ -124,11 +124,11 @@ const Router = component<RouterProps>(
     }));
 
     return (
-      <RouterHistoryContext.Provider value={historyContext}>
-        <ActiveRouteContext.Provider value={routerContext}>
-          <PendingContext.Provider value={pending$}>{slot(content)}</PendingContext.Provider>
-        </ActiveRouteContext.Provider>
-      </RouterHistoryContext.Provider>
+      <RouterHistoryContext value={historyContext}>
+        <ActiveRouteContext value={routerContext}>
+          <PendingContext value={pending$}>{slot(content)}</PendingContext>
+        </ActiveRouteContext>
+      </RouterHistoryContext>
     );
   },
   { displayName: 'Router' },


### PR DESCRIPTION
Removed unnecessary `Context.Provider` and `Context.Consumer`. Now the context itself is a provider.

It was like this
```tsx
<SomeContext.Provider value={value}>
  ...
</SomeContext.Provider>
```
then it became like that

```tsx
<SomeContext value={value}>
 ...
</SomeContext>
```
